### PR TITLE
Switch Node version to LTS in Travis config (to fix the build)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: node
+node_js: lts/*
 
 # work around a Chrome startup crash issue:
 #   https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356339798


### PR DESCRIPTION
The current non-LTS version of Node (10.0.0) seems to be incompatible with the current web-components-tester (or its dependencies), results in the following error:
```
error:   TypeError: Cannot read property '1' of null
    at module.exports (/home/travis/.nvm/versions/node/v10.0.0/lib/node_modules/polymer-cli/node_modules/promisify-node/utils/args.js:9:63)
    at processExports (/home/travis/.nvm/versions/node/v10.0.0/lib/node_modules/polymer-cli/node_modules/promisify-node/index.js:61:29)
...
```
Using the LTS version of node (version 8.11.1 currently) seems to solve this problem.